### PR TITLE
fix: typo in config breaks delta backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ require("tiny-code-action").setup({
 
 			-- Header from delta can be quite large.
 			-- You can remove them by setting this to the number of lines to remove
-			header_lines_to_removed = 4,
+			header_lines_to_remove = 4,
 		},
 	},
 	telescope_opts = {

--- a/lua/tiny-code-action/init.lua
+++ b/lua/tiny-code-action/init.lua
@@ -24,7 +24,7 @@ M.config = {
 			override_cmd = nil,
 			use_git_config = false,
 			config_path = nil,
-			header_lines_to_removed = 4,
+			header_lines_to_remove = 4,
 			-- config_path = nil,
 		},
 	},


### PR DESCRIPTION
Because of the extra 'd', the config value lookup fails, causing this error:

```lua
E5108: Error executing lua: ...-code-action.nvim/lua/tiny-code-action/backend/delta.lua:60: 'for' limit must be a number
```
