### PR TITLE
fix: check if setup opts empty

### DIFF
--- a/lua/tiny-code-action/init.lua
+++ b/lua/tiny-code-action/init.lua
@@ -303,7 +303,7 @@ end
 function M.setup(opts)
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
 
-	if opts.telescope_opts then
+	if opts and opts.telescope_opts then
 		M.config.telescope_opts = vim.tbl_extend("force", M.config.telescope_opts, opts.telescope_opts)
 	end
 


### PR DESCRIPTION
this check was forgotten, which leads to attempting to index nil