### PR TITLE
feat(delta): add scroll_fn support

### DIFF
--- a/lua/tiny-code-action/backend/delta.lua
+++ b/lua/tiny-code-action/backend/delta.lua
@@ -79,6 +79,18 @@ function M.create_previewer(opts, bufnr, backend, preview_action_callback)
 
 			return { "echo", table.concat(preview_lines, "\n") .. string.rep("\n", vim.o.lines) } -- HACK: to prevent `Process exited` message
 		end,
+		scroll_fn = function(self, direction)
+			if not self.state then
+				return
+			end
+
+			local input = vim.api.nvim_replace_termcodes(direction > 0 and "<C-e>" or "<C-y>", true, false, true)
+			local count = math.abs(direction)
+
+			vim.api.nvim_win_call(vim.fn.bufwinid(self.state.termopen_bufnr), function()
+				vim.cmd([[normal! ]] .. count .. input)
+			end)
+		end,
 	})
 end
 


### PR DESCRIPTION
Some actions may need to scroll vertically (via `<C-u>` and `<C-d>` in my own config) to see the whole preview.

Copied some codes from [here](https://github.com/petobens/dotfiles/blob/0e216cdf8048859db5cbec0a1bc5b99d45479817/nvim/lua/plugin-config/telescope_config.lua#L35) and [here](https://github.com/nvim-telescope/telescope.nvim/blob/85922dde3767e01d42a08e750a773effbffaea3e/lua/telescope/previewers/buffer_previewer.lua#L310).
