### PR TITLE
chore(docs): Streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 A Neovim plugin that provides a simple way to run and visualize code actions.
 
+[Preview](#preview) • [Installation](#installation) • [Options](#options) • [FAQ](#faq)
+
 Supported pickers:
-- `vim.ui.select`
+- `vim.ui.select` (`fzf-lua`)
 - `telescope.nvim`
 - `snacks.nvim`
 
@@ -28,8 +30,6 @@ The code action protocol is nearly fully implemented in this plugin, so you can 
 
 ![tinycode_difftastic_1](https://github.com/user-attachments/assets/7fbdb52f-455f-4d4f-a2e6-434b14c4f21f)
 
-### Installation
-
 ## 📥 Installation
 
 > [!NOTE]
@@ -44,8 +44,11 @@ With Lazy.nvim:
     dependencies = {
         {"nvim-lua/plenary.nvim"},
 
-        -- optional
+        -- optional picker via telescope
         {"nvim-telescope/telescope.nvim"},
+        -- .. or via fzf-lua
+        {"ibhagwan/fzf-lua"},
+        -- .. or via snacks
         {
           "folke/snacks.nvim",
           opts = {
@@ -54,9 +57,7 @@ With Lazy.nvim:
         }
     },
     event = "LspAttach",
-    config = function()
-        require('tiny-code-action').setup()
-    end
+    opts = {},
 }
 ```
 
@@ -78,67 +79,76 @@ end, { noremap = true, silent = true })
 > If you want optimal performance, use the `vim` backend.
 
 ```lua
-require("tiny-code-action").setup({
-	--- The backend to use, currently only "vim", "delta" and "difftastic" are supported
-	backend = "vim",
-  pickers = "snacks" -- The picker to use, "telescope", "snacks", "select" are supported
-	backend_opts = {
-		delta = {
-			-- Header from delta can be quite large.
-			-- You can remove them by setting this to the number of lines to remove
-			header_lines_to_remove = 4,
+{
+    "rachartier/tiny-code-action.nvim",
+    dependencies = {
+        {"nvim-lua/plenary.nvim"},
+    },
+    event = "LspAttach",
+    opts = {
+      --- The backend to use, currently only "vim", "delta" and "difftastic" are supported
+      backend = "vim",
+      -- The picker to use, "telescope", "snacks", "select" are supported
+      -- If you want to use the `fzf-lua` picker, you can simply set it to `select`
+      picker = "snacks"
+      backend_opts = {
+        delta = {
+          -- Header from delta can be quite large.
+          -- You can remove them by setting this to the number of lines to remove
+          header_lines_to_remove = 4,
 
-			-- The arguments to pass to delta
-			-- If you have a custom configuration file, you can set the path to it like so:
-			-- args = {
-			--     "--config" .. os.getenv("HOME") .. "/.config/delta/config.yml",
-			-- }
-			args = {
-				"--line-numbers",
-			},
-		},
-		difftastic = {
-			-- Header from delta can be quite large.
-			-- You can remove them by setting this to the number of lines to remove
-			header_lines_to_remove = 1,
+          -- The arguments to pass to delta
+          -- If you have a custom configuration file, you can set the path to it like so:
+          -- args = {
+          --     "--config" .. os.getenv("HOME") .. "/.config/delta/config.yml",
+          -- }
+          args = {
+            "--line-numbers",
+          },
+        },
+        difftastic = {
+          -- Header from delta can be quite large.
+          -- You can remove them by setting this to the number of lines to remove
+          header_lines_to_remove = 1,
 
-			-- The arguments to pass to difftastic
-			args = {
-				"--color=always",
-				"--display=inline",
-				"--syntax-highlight=on",
-			},
-		},
-	},
-  -- Will be removed in future versions
-	telescope_opts = {
-		layout_strategy = "vertical",
-		layout_config = {
-			width = 0.7,
-			height = 0.9,
-			preview_cutoff = 1,
-			preview_height = function(_, _, max_lines)
-				local h = math.floor(max_lines * 0.5)
-				return math.max(h, 10)
-			end,
-		},
-	},
-	-- The icons to use for the code actions
-	-- You can add your own icons, you just need to set the exact action's kind of the code action
-	-- You can set the highlight like so: { link = "DiagnosticError" } or  like nvim_set_hl ({ fg ..., bg..., bold..., ...})
-	signs = {
-		quickfix = { "󰁨", { link = "DiagnosticInfo" } },
-		others = { "?", { link = "DiagnosticWarning" } },
-		refactor = { "", { link = "DiagnosticWarning" } },
-		["refactor.move"] = { "󰪹", { link = "DiagnosticInfo" } },
-		["refactor.extract"] = { "", { link = "DiagnosticError" } },
-		["source.organizeImports"] = { "", { link = "DiagnosticWarning" } },
-		["source.fixAll"] = { "", { link = "DiagnosticError" } },
-		["source"] = { "", { link = "DiagnosticError" } },
-		["rename"] = { "󰑕", { link = "DiagnosticWarning" } },
-		["codeAction"] = { "", { link = "DiagnosticError" } },
-	},
-})
+          -- The arguments to pass to difftastic
+          args = {
+            "--color=always",
+            "--display=inline",
+            "--syntax-highlight=on",
+          },
+        },
+      },
+      -- Will be removed in future versions
+      telescope_opts = {
+        layout_strategy = "vertical",
+        layout_config = {
+          width = 0.7,
+          height = 0.9,
+          preview_cutoff = 1,
+          preview_height = function(_, _, max_lines)
+            local h = math.floor(max_lines * 0.5)
+            return math.max(h, 10)
+          end,
+        },
+      },
+      -- The icons to use for the code actions
+      -- You can add your own icons, you just need to set the exact action's kind of the code action
+      -- You can set the highlight like so: { link = "DiagnosticError" } or  like nvim_set_hl ({ fg ..., bg..., bold..., ...})
+      signs = {
+        quickfix = { "󰁨", { link = "DiagnosticInfo" } },
+        others = { "?", { link = "DiagnosticWarning" } },
+        refactor = { "", { link = "DiagnosticWarning" } },
+        ["refactor.move"] = { "󰪹", { link = "DiagnosticInfo" } },
+        ["refactor.extract"] = { "", { link = "DiagnosticError" } },
+        ["source.organizeImports"] = { "", { link = "DiagnosticWarning" } },
+        ["source.fixAll"] = { "", { link = "DiagnosticError" } },
+        ["source"] = { "", { link = "DiagnosticError" } },
+        ["rename"] = { "󰑕", { link = "DiagnosticWarning" } },
+        ["codeAction"] = { "", { link = "DiagnosticError" } },
+      },
+   }
+}
 ```
 
 
@@ -152,12 +162,10 @@ You can filter the code actions by setting the `filters` option.
     kind = "refactor" -- Filter to the kind
     client = "omnisharp" -- Filter to the client
 }
-
 ```
 
 Example:
 ```lua
-
 require("tiny-code-action").code_action({
         filters = {
         kind = "refactor",
@@ -168,6 +176,7 @@ require("tiny-code-action").code_action({
 
 
 ## ❓ FAQ:
+
 - How to look like the preview?
 	- You can find my `delta` configuration here: ![rachartier/dotfiles/delta](https://github.com/rachartier/dotfiles/tree/main/.config/delta)
     - Then you can set the `config_path` to the path of your configuration file.


### PR DESCRIPTION
- Fix `pickers` option versus actual `picker`
- Remove newlines in code-blocks to make them all the same
- Add TOC to README
- Change lazy install instructions to `opts`, because best-practice?!
- Add hint that fzf-lua is indirectly supported via `select`