### PR TITLE
Only open picker when code actions are found

### DIFF
--- a/lua/tiny-code-action/init.lua
+++ b/lua/tiny-code-action/init.lua
@@ -148,6 +148,7 @@ local function code_action_finder(opts, callback)
 		if client_count_done == #clients then
 			if vim.tbl_isempty(results) then
 				vim.notify("No code actions found.", vim.log.levels.INFO)
+				return
 			end
 
 			callback(results)


### PR DESCRIPTION
In 7f6bfc0, the early return in `code_action_finder()` when no actions are found was seemingly left behind. Now, when none are found, tiny-code-action both notifies *and* opens an empty picker the user must close.

Since users are already notified, I assume it'd make more sense to avoid opening the picker when there's nothing to pick. To do that, this PR adds back an early return before the `code_action_finder()` callback.

It's trivial, and maybe you just forgot to do it, so I forwent opening an issue. Hoping I got it right.