### PR TITLE
fix(buffer): position=cursor uses the right location

### DIFF
--- a/lua/tiny-code-action/pickers/buffer_utils/preview.lua
+++ b/lua/tiny-code-action/pickers/buffer_utils/preview.lua
@@ -101,24 +101,33 @@ function M.show_preview(
     local orig_preview_width = math.floor(nvim_width * 0.4)
     local orig_preview_height = math.floor(nvim_height * 0.4)
     local preview_row, preview_col, preview_width, preview_height
+    local margin = main_win_config.margin
+    local win_row, win_col = unpack(vim.api.nvim_win_get_position(0))
+    local south_space = nvim_height - win_row - main_height - margin
+    local north_space = win_row - margin
 
-    if main_col + main_width + 2 + orig_preview_width <= nvim_width then
+    if win_col + main_width + margin + orig_preview_width <= nvim_width then
       preview_width = orig_preview_width
       preview_height = orig_preview_height
       preview_row = main_row
-      preview_col = main_col + main_width + 2
-    else
-      local south_space = nvim_height - (main_row + main_height) - 2
-      local north_space = main_row - 2
+      preview_col = main_col + main_width + margin
+    elseif win_col > margin + orig_preview_width then
+      preview_width = orig_preview_width
+      preview_height = orig_preview_height
+      preview_row = main_row
+      preview_col = win_col - margin - orig_preview_width
+    elseif south_space >= north_space then
       preview_width = main_width
-      preview_height = math.ceil(orig_preview_height / 2)
-      if south_space >= north_space then
-        preview_row = main_row + main_height + 2
-        preview_col = main_col
-      else
-        preview_row = math.max(0, main_row - preview_height - 2)
-        preview_col = main_col
-      end
+      preview_height =
+        math.max(0, math.min(math.ceil(orig_preview_height / 2), south_space - margin))
+      preview_row = win_row + main_height + margin
+      preview_col = main_col
+    else
+      preview_width = main_width
+      preview_height =
+        math.max(0, math.min(math.ceil(orig_preview_height / 2), north_space - margin))
+      preview_row = win_row - preview_height - margin
+      preview_col = main_col
     end
 
     local preview_buf = vim.api.nvim_create_buf(false, true)

--- a/lua/tiny-code-action/pickers/buffer_utils/window.lua
+++ b/lua/tiny-code-action/pickers/buffer_utils/window.lua
@@ -1,6 +1,7 @@
 local display = require("tiny-code-action.pickers.buffer_utils.display")
 local preview = require("tiny-code-action.pickers.buffer_utils.preview")
 local utils = require("tiny-code-action.utils")
+local margin = 2
 
 local M = {}
 
@@ -15,7 +16,7 @@ end
 
 local function calculate_window_position(lines, config)
   local width, height = display.calculate_window_size(lines)
-  local row, col
+  local row, col, win_row, win_col, shift
   local position = config.picker and config.picker.opts and config.picker.opts.position or "cursor"
 
   if position == "center" then
@@ -24,9 +25,12 @@ local function calculate_window_position(lines, config)
     row = math.floor((nvim_height - height) / 2)
     col = math.floor((nvim_width - width) / 2)
   else
-    local cursor_row = vim.api.nvim_win_get_cursor(0)[1] - 1
-    row = cursor_row + 2
-    col = 2
+    win_row, win_col = unpack(vim.api.nvim_win_get_position(0))
+    row = vim.fn.winline()
+    col = vim.fn.wincol()
+    shift = math.max(0, col - math.floor(width / 2))
+    row = win_row + row + margin
+    col = win_col + shift
   end
 
   return width, height, row, col
@@ -172,6 +176,7 @@ function M.create_main_window(
 
   local win = vim.api.nvim_open_win(buf, true, win_config)
   win_config.win = win
+  win_config.margin = margin
   vim.api.nvim_win_set_cursor(win, { 2, 0 })
 
   utils.set_buf_option(buf, "modifiable", false)


### PR DESCRIPTION
With position="cursor" for the buffer picker it works alright when the line number of the code action is small and at the top of the window. If the line number is close to or larger than window height the picker stays glued to the bottom left corner even if cursor position is at the top right corner. This PR changes that to the expected behaviour