### PR TITLE
feat(telescope): allow differnt layouts for telescope

### DIFF
--- a/lua/tiny-code-action/config.lua
+++ b/lua/tiny-code-action/config.lua
@@ -1,95 +1,95 @@
 local M = {}
 
 M.VALID_PICKERS = {
-    telescope = true,
-    snacks = true,
-    select = true,
-    buffer = true,
+  telescope = true,
+  snacks = true,
+  select = true,
+  buffer = true,
 }
 
 M.VALID_BACKENDS = {
-    vim = true,
-    delta = true,
-    difftastic = true,
-    diffsofancy = true,
+  vim = true,
+  delta = true,
+  difftastic = true,
+  diffsofancy = true,
 }
 
 M.picker_config = {
-    telescope = {
-        layout_strategy = "vertical",
-        layout_config = function(layout)
-            if layout == "horizontal" then
-                return {
-                    width = 0.7,
-                    height = 0.9,
-                    preview_cutoff = 1,
-                }
-            else
-                return {
-                    width = 0.7,
-                    height = 0.9,
-                    preview_cutoff = 1,
-                    preview_height = function(_, _, max_lines)
-                        local h = math.floor(max_lines * 0.5)
-                        return math.max(h, 10)
-                    end
-                }
-            end
-        end
+  telescope = {
+    layout_strategy = "vertical",
+    layout_config = function(layout)
+      if layout == "horizontal" then
+        return {
+          width = 0.7,
+          height = 0.9,
+          preview_cutoff = 1,
+        }
+      else
+        return {
+          width = 0.7,
+          height = 0.9,
+          preview_cutoff = 1,
+          preview_height = function(_, _, max_lines)
+            local h = math.floor(max_lines * 0.5)
+            return math.max(h, 10)
+          end
+        }
+      end
+    end
+  },
+  snacks = {
+    layout = "vertical",
+  },
+  select = {},
+  buffer = {
+    hotkeys = false,
+    hotkeys_mode = "text_diff_based",     -- can also be a function(titles, used_hotkeys) returning a list of hotkey strings
+    auto_preview = false,
+    auto_accept = false,
+    position = "cursor",
+    winborder = nil,
+    conceallevel = 1,
+    keymaps = {
+      preview = "K",
+      close = "q",
     },
-    snacks = {
-        layout = "vertical",
-    },
-    select = {},
-    buffer = {
-        hotkeys = false,
-        hotkeys_mode = "text_diff_based", -- can also be a function(titles, used_hotkeys) returning a list of hotkey strings
-        auto_preview = false,
-        auto_accept = false,
-        position = "cursor",
-        winborder = nil,
-        conceallevel = 1,
-        keymaps = {
-            preview = "K",
-            close = "q",
-        },
-    },
+  },
 }
 
 M.default_config = {
-    backend = "vim",
-    picker = "telescope",
-    backend_opts = {
-        delta = {
-            header_lines_to_remove = 4,
-            args = {
-                "--line-numbers",
-            },
-        },
-        difftastic = {
-            header_lines_to_remove = 1,
-            args = {
-                "--color=always",
-                "--display=inline",
-                "--syntax-highlight=on",
-            },
-        },
-        diffsofancy = {
-            header_lines_to_remove = 4,
-        },
+  backend = "vim",
+  picker = "telescope",
+  backend_opts = {
+    delta = {
+      header_lines_to_remove = 4,
+      args = {
+        "--line-numbers",
+      },
     },
-    signs = {
-        quickfix = { "", { link = "DiagnosticWarning" } },
-        others = { "", { link = "DiagnosticWarning" } },
-        refactor = { "", { link = "DiagnosticInfo" } },
-        ["refactor.move"] = { "󰪹", { link = "DiagnosticInfo" } },
-        ["refactor.extract"] = { "", { link = "DiagnosticError" } },
-        ["source.organizeImports"] = { "", { link = "DiagnosticWarning" } },
-        ["source.fixAll"] = { "󰃢", { link = "DiagnosticError" } },
-        ["source"] = { "", { link = "DiagnosticError" } },
-        ["rename"] = { "󰑕", { link = "DiagnosticWarning" } },
-        ["codeAction"] = { "", { link = "DiagnosticWarning" } },
+    difftastic = {
+      header_lines_to_remove = 1,
+      args = {
+        "--color=always",
+        "--display=inline",
+        "--syntax-highlight=on",
+      },
     },
+    diffsofancy = {
+      header_lines_to_remove = 4,
+    },
+  },
+  signs = {
+    quickfix = { "", { link = "DiagnosticWarning" } },
+    others = { "", { link = "DiagnosticWarning" } },
+    refactor = { "", { link = "DiagnosticInfo" } },
+    ["refactor.move"] = { "󰪹", { link = "DiagnosticInfo" } },
+    ["refactor.extract"] = { "", { link = "DiagnosticError" } },
+    ["source.organizeImports"] = { "", { link = "DiagnosticWarning" } },
+    ["source.fixAll"] = { "󰃢", { link = "DiagnosticError" } },
+    ["source"] = { "", { link = "DiagnosticError" } },
+    ["rename"] = { "󰑕", { link = "DiagnosticWarning" } },
+    ["codeAction"] = { "", { link = "DiagnosticWarning" } },
+  },
 }
 
 return M

--- a/lua/tiny-code-action/config.lua
+++ b/lua/tiny-code-action/config.lua
@@ -1,85 +1,95 @@
 local M = {}
 
 M.VALID_PICKERS = {
-  telescope = true,
-  snacks = true,
-  select = true,
-  buffer = true,
+    telescope = true,
+    snacks = true,
+    select = true,
+    buffer = true,
 }
 
 M.VALID_BACKENDS = {
-  vim = true,
-  delta = true,
-  difftastic = true,
-  diffsofancy = true,
+    vim = true,
+    delta = true,
+    difftastic = true,
+    diffsofancy = true,
 }
 
 M.picker_config = {
-  telescope = {
-    layout_strategy = "vertical",
-    layout_config = {
-      width = 0.7,
-      height = 0.9,
-      preview_cutoff = 1,
-      preview_height = function(_, _, max_lines)
-        local h = math.floor(max_lines * 0.5)
-        return math.max(h, 10)
-      end,
+    telescope = {
+        layout_strategy = "vertical",
+        layout_config = function(layout)
+            if layout == "horizontal" then
+                return {
+                    width = 0.7,
+                    height = 0.9,
+                    preview_cutoff = 1,
+                }
+            else
+                return {
+                    width = 0.7,
+                    height = 0.9,
+                    preview_cutoff = 1,
+                    preview_height = function(_, _, max_lines)
+                        local h = math.floor(max_lines * 0.5)
+                        return math.max(h, 10)
+                    end
+                }
+            end
+        end
     },
-  },
-  snacks = {
-    layout = "vertical",
-  },
-  select = {},
-  buffer = {
-    hotkeys = false,
-    hotkeys_mode = "text_diff_based", -- can also be a function(titles, used_hotkeys) returning a list of hotkey strings
-    auto_preview = false,
-    auto_accept = false,
-    position = "cursor",
-    winborder = nil,
-    conceallevel = 1,
-    keymaps = {
-      preview = "K",
-      close = "q",
+    snacks = {
+        layout = "vertical",
     },
-  },
+    select = {},
+    buffer = {
+        hotkeys = false,
+        hotkeys_mode = "text_diff_based", -- can also be a function(titles, used_hotkeys) returning a list of hotkey strings
+        auto_preview = false,
+        auto_accept = false,
+        position = "cursor",
+        winborder = nil,
+        conceallevel = 1,
+        keymaps = {
+            preview = "K",
+            close = "q",
+        },
+    },
 }
 
 M.default_config = {
-  backend = "vim",
-  picker = "telescope",
-  backend_opts = {
-    delta = {
-      header_lines_to_remove = 4,
-      args = {
-        "--line-numbers",
-      },
+    backend = "vim",
+    picker = "telescope",
+    backend_opts = {
+        delta = {
+            header_lines_to_remove = 4,
+            args = {
+                "--line-numbers",
+            },
+        },
+        difftastic = {
+            header_lines_to_remove = 1,
+            args = {
+                "--color=always",
+                "--display=inline",
+                "--syntax-highlight=on",
+            },
+        },
+        diffsofancy = {
+            header_lines_to_remove = 4,
+        },
     },
-    difftastic = {
-      header_lines_to_remove = 1,
-      args = {
-        "--color=always",
-        "--display=inline",
-        "--syntax-highlight=on",
-      },
+    signs = {
+        quickfix = { "", { link = "DiagnosticWarning" } },
+        others = { "", { link = "DiagnosticWarning" } },
+        refactor = { "", { link = "DiagnosticInfo" } },
+        ["refactor.move"] = { "󰪹", { link = "DiagnosticInfo" } },
+        ["refactor.extract"] = { "", { link = "DiagnosticError" } },
+        ["source.organizeImports"] = { "", { link = "DiagnosticWarning" } },
+        ["source.fixAll"] = { "󰃢", { link = "DiagnosticError" } },
+        ["source"] = { "", { link = "DiagnosticError" } },
+        ["rename"] = { "󰑕", { link = "DiagnosticWarning" } },
+        ["codeAction"] = { "", { link = "DiagnosticWarning" } },
     },
-    diffsofancy = {
-      header_lines_to_remove = 4,
-    },
-  },
-  signs = {
-    quickfix = { "", { link = "DiagnosticWarning" } },
-    others = { "", { link = "DiagnosticWarning" } },
-    refactor = { "", { link = "DiagnosticInfo" } },
-    ["refactor.move"] = { "󰪹", { link = "DiagnosticInfo" } },
-    ["refactor.extract"] = { "", { link = "DiagnosticError" } },
-    ["source.organizeImports"] = { "", { link = "DiagnosticWarning" } },
-    ["source.fixAll"] = { "󰃢", { link = "DiagnosticError" } },
-    ["source"] = { "", { link = "DiagnosticError" } },
-    ["rename"] = { "󰑕", { link = "DiagnosticWarning" } },
-    ["codeAction"] = { "", { link = "DiagnosticWarning" } },
-  },
 }
 
 return M

--- a/lua/tiny-code-action/init.lua
+++ b/lua/tiny-code-action/init.lua
@@ -15,132 +15,132 @@ M.picker_config = config.picker_config
 --- Gets and displays code actions for the current buffer, applying filters and using the configured picker.
 --- @param opts table: Options for code actions (compatible with vim.lsp.buf.code_action)
 function M.code_action(opts)
-    local bufnr = vim.api.nvim_get_current_buf()
-    local finder_opts = {
-        bufnr = bufnr,
-        context = opts and opts.context,
-        range = opts and opts.range,
-    }
-    finder.code_action_finder(finder_opts, function(results)
-        if opts == nil then
-            opts = {}
+  local bufnr = vim.api.nvim_get_current_buf()
+  local finder_opts = {
+    bufnr = bufnr,
+    context = opts and opts.context,
+    range = opts and opts.range,
+  }
+  finder.code_action_finder(finder_opts, function(results)
+    if opts == nil then
+      opts = {}
+    end
+    if opts.context and opts.context.only then
+      results = filters.filter_code_actions(results, { only = opts.context.only })
+    end
+    if opts.filters ~= nil then
+      results = filters.filter_code_actions(results, opts.filters)
+    end
+    if opts.filter and type(opts.filter) == "function" then
+      local filtered_results = {}
+
+      for _, result in ipairs(results) do
+        if opts.filter(result.action) then
+          table.insert(filtered_results, result)
         end
-        if opts.context and opts.context.only then
-            results = filters.filter_code_actions(results, { only = opts.context.only })
-        end
-        if opts.filters ~= nil then
-            results = filters.filter_code_actions(results, opts.filters)
-        end
-        if opts.filter and type(opts.filter) == "function" then
-            local filtered_results = {}
+      end
 
-            for _, result in ipairs(results) do
-                if opts.filter(result.action) then
-                    table.insert(filtered_results, result)
-                end
-            end
+      results = filtered_results
+    end
 
-            results = filtered_results
-        end
+    results = finder.sort_by_preferred(results)
 
-        results = finder.sort_by_preferred(results)
+    if results == nil or #results == 0 then
+      vim.notify("No code actions found.", vim.log.levels.INFO)
+      return
+    end
 
-        if results == nil or #results == 0 then
-            vim.notify("No code actions found.", vim.log.levels.INFO)
-            return
-        end
+    if opts.apply and #results == 1 then
+      local action = results[1]
 
-        if opts.apply and #results == 1 then
-            local action = results[1]
+      if action.action.edit then
+        vim.lsp.util.apply_workspace_edit(action.action.edit, action.client.offset_encoding)
+      end
 
-            if action.action.edit then
-                vim.lsp.util.apply_workspace_edit(action.action.edit, action.client.offset_encoding)
-            end
-
-            if action.action.command then
-                if action.client.commands and action.client.commands[action.action.command.command] then
-                    action.client.commands[action.action.command.command](
-                        action.action.command,
-                        { bufnr = bufnr }
-                    )
-                else
-                    action.client:exec_cmd(action.action.command, { bufnr = bufnr })
-                end
-            end
-
-            return
-        end
-
-        local picker_name
-
-        if type(M.config.picker) == "table" then
-            picker_name = M.config.picker[1]
+      if action.action.command then
+        if action.client.commands and action.client.commands[action.action.command.command] then
+          action.client.commands[action.action.command.command](
+            action.action.command,
+            { bufnr = bufnr }
+          )
         else
-            picker_name = M.config.picker or "telescope"
+          action.client:exec_cmd(action.action.command, { bufnr = bufnr })
         end
+      end
 
-        local picker_module = picker_util.get_picker_module(picker_name)
+      return
+    end
 
-        if not picker_module then
-            vim.notify(
-                "No picker module could be loaded. Aborting code action display.",
-                vim.log.levels.ERROR
-            )
-            return
-        end
+    local picker_name
 
-        picker_module.match_hl_kind = M.match_hl_kind
-        picker_module.backend = M.backend
-        picker_module.create(M.config, results, bufnr)
-    end)
+    if type(M.config.picker) == "table" then
+      picker_name = M.config.picker[1]
+    else
+      picker_name = M.config.picker or "telescope"
+    end
+
+    local picker_module = picker_util.get_picker_module(picker_name)
+
+    if not picker_module then
+      vim.notify(
+        "No picker module could be loaded. Aborting code action display.",
+        vim.log.levels.ERROR
+      )
+      return
+    end
+
+    picker_module.match_hl_kind = M.match_hl_kind
+    picker_module.backend = M.backend
+    picker_module.create(M.config, results, bufnr)
+  end)
 end
 
 local function init_backend(backend_name)
-    if type(backend_name) ~= "string" then
-        error("Invalid backend type: " .. type(backend_name))
-        return nil
-    end
+  if type(backend_name) ~= "string" then
+    error("Invalid backend type: " .. type(backend_name))
+    return nil
+  end
 
-    if not config.VALID_BACKENDS[backend_name] then
-        error("Invalid backend: " .. backend_name)
-        return nil
-    end
+  if not config.VALID_BACKENDS[backend_name] then
+    error("Invalid backend: " .. backend_name)
+    return nil
+  end
 
-    return require("tiny-code-action.backend." .. backend_name)
+  return require("tiny-code-action.backend." .. backend_name)
 end
 
 --- Sets up the plugin configuration, picker, highlights, and backend.
 --- @param opts table: User configuration options
 function M.setup(opts)
-    M.config = vim.tbl_deep_extend("force", {}, M.config, opts or {})
+  M.config = vim.tbl_deep_extend("force", {}, M.config, opts or {})
 
-    local picker_name = type(M.config.picker) == "table" and M.config.picker[1] or M.config.picker
-    local default_picker_opts = M.picker_config[picker_name] or {}
+  local picker_name = type(M.config.picker) == "table" and M.config.picker[1] or M.config.picker
+  local default_picker_opts = M.picker_config[picker_name] or {}
 
-    if type(default_picker_opts) == "function" then
-        default_picker_opts = default_picker_opts(picker_name)
-        print(default_picker_opts)
-    end
+  if type(default_picker_opts) == "function" then
+    default_picker_opts = default_picker_opts(picker_name)
+    print(default_picker_opts)
+  end
 
-    if type(M.config.picker) == "string" then
-        M.config.picker = {
-            M.config.picker,
-            opts = vim.tbl_deep_extend("force", {}, default_picker_opts),
-        }
+  if type(M.config.picker) == "string" then
+    M.config.picker = {
+      M.config.picker,
+      opts = vim.tbl_deep_extend("force", {}, default_picker_opts),
+    }
+  else
+    if not M.config.picker.opts then
+      M.config.picker.opts = vim.tbl_deep_extend("force", {}, default_picker_opts)
     else
-        if not M.config.picker.opts then
-            M.config.picker.opts = vim.tbl_deep_extend("force", {}, default_picker_opts)
-        else
-            M.config.picker.opts =
-                vim.tbl_deep_extend("force", {}, default_picker_opts, M.config.picker.opts)
-        end
+      M.config.picker.opts =
+          vim.tbl_deep_extend("force", {}, default_picker_opts, M.config.picker.opts)
     end
+  end
 
-    picker_util.init_picker(M.config.picker)
-    highlights.setup_highlights(M.config.signs)
+  picker_util.init_picker(M.config.picker)
+  highlights.setup_highlights(M.config.signs)
 
-    M.backend = init_backend(M.config.backend)
-    M.match_hl_kind = highlights.match_hl_kind or {}
+  M.backend = init_backend(M.config.backend)
+  M.match_hl_kind = highlights.match_hl_kind or {}
 end
 
 return M

--- a/lua/tiny-code-action/init.lua
+++ b/lua/tiny-code-action/init.lua
@@ -15,127 +15,132 @@ M.picker_config = config.picker_config
 --- Gets and displays code actions for the current buffer, applying filters and using the configured picker.
 --- @param opts table: Options for code actions (compatible with vim.lsp.buf.code_action)
 function M.code_action(opts)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local finder_opts = {
-    bufnr = bufnr,
-    context = opts and opts.context,
-    range = opts and opts.range,
-  }
-  finder.code_action_finder(finder_opts, function(results)
-    if opts == nil then
-      opts = {}
-    end
-    if opts.context and opts.context.only then
-      results = filters.filter_code_actions(results, { only = opts.context.only })
-    end
-    if opts.filters ~= nil then
-      results = filters.filter_code_actions(results, opts.filters)
-    end
-    if opts.filter and type(opts.filter) == "function" then
-      local filtered_results = {}
-
-      for _, result in ipairs(results) do
-        if opts.filter(result.action) then
-          table.insert(filtered_results, result)
+    local bufnr = vim.api.nvim_get_current_buf()
+    local finder_opts = {
+        bufnr = bufnr,
+        context = opts and opts.context,
+        range = opts and opts.range,
+    }
+    finder.code_action_finder(finder_opts, function(results)
+        if opts == nil then
+            opts = {}
         end
-      end
+        if opts.context and opts.context.only then
+            results = filters.filter_code_actions(results, { only = opts.context.only })
+        end
+        if opts.filters ~= nil then
+            results = filters.filter_code_actions(results, opts.filters)
+        end
+        if opts.filter and type(opts.filter) == "function" then
+            local filtered_results = {}
 
-      results = filtered_results
-    end
+            for _, result in ipairs(results) do
+                if opts.filter(result.action) then
+                    table.insert(filtered_results, result)
+                end
+            end
 
-    results = finder.sort_by_preferred(results)
+            results = filtered_results
+        end
 
-    if results == nil or #results == 0 then
-      vim.notify("No code actions found.", vim.log.levels.INFO)
-      return
-    end
+        results = finder.sort_by_preferred(results)
 
-    if opts.apply and #results == 1 then
-      local action = results[1]
+        if results == nil or #results == 0 then
+            vim.notify("No code actions found.", vim.log.levels.INFO)
+            return
+        end
 
-      if action.action.edit then
-        vim.lsp.util.apply_workspace_edit(action.action.edit, action.client.offset_encoding)
-      end
+        if opts.apply and #results == 1 then
+            local action = results[1]
 
-      if action.action.command then
-        if action.client.commands and action.client.commands[action.action.command.command] then
-          action.client.commands[action.action.command.command](
-            action.action.command,
-            { bufnr = bufnr }
-          )
+            if action.action.edit then
+                vim.lsp.util.apply_workspace_edit(action.action.edit, action.client.offset_encoding)
+            end
+
+            if action.action.command then
+                if action.client.commands and action.client.commands[action.action.command.command] then
+                    action.client.commands[action.action.command.command](
+                        action.action.command,
+                        { bufnr = bufnr }
+                    )
+                else
+                    action.client:exec_cmd(action.action.command, { bufnr = bufnr })
+                end
+            end
+
+            return
+        end
+
+        local picker_name
+
+        if type(M.config.picker) == "table" then
+            picker_name = M.config.picker[1]
         else
-          action.client:exec_cmd(action.action.command, { bufnr = bufnr })
+            picker_name = M.config.picker or "telescope"
         end
-      end
 
-      return
-    end
+        local picker_module = picker_util.get_picker_module(picker_name)
 
-    local picker_name
+        if not picker_module then
+            vim.notify(
+                "No picker module could be loaded. Aborting code action display.",
+                vim.log.levels.ERROR
+            )
+            return
+        end
 
-    if type(M.config.picker) == "table" then
-      picker_name = M.config.picker[1]
-    else
-      picker_name = M.config.picker or "telescope"
-    end
-
-    local picker_module = picker_util.get_picker_module(picker_name)
-
-    if not picker_module then
-      vim.notify(
-        "No picker module could be loaded. Aborting code action display.",
-        vim.log.levels.ERROR
-      )
-      return
-    end
-
-    picker_module.match_hl_kind = M.match_hl_kind
-    picker_module.backend = M.backend
-    picker_module.create(M.config, results, bufnr)
-  end)
+        picker_module.match_hl_kind = M.match_hl_kind
+        picker_module.backend = M.backend
+        picker_module.create(M.config, results, bufnr)
+    end)
 end
 
 local function init_backend(backend_name)
-  if type(backend_name) ~= "string" then
-    error("Invalid backend type: " .. type(backend_name))
-    return nil
-  end
+    if type(backend_name) ~= "string" then
+        error("Invalid backend type: " .. type(backend_name))
+        return nil
+    end
 
-  if not config.VALID_BACKENDS[backend_name] then
-    error("Invalid backend: " .. backend_name)
-    return nil
-  end
+    if not config.VALID_BACKENDS[backend_name] then
+        error("Invalid backend: " .. backend_name)
+        return nil
+    end
 
-  return require("tiny-code-action.backend." .. backend_name)
+    return require("tiny-code-action.backend." .. backend_name)
 end
 
 --- Sets up the plugin configuration, picker, highlights, and backend.
 --- @param opts table: User configuration options
 function M.setup(opts)
-  M.config = vim.tbl_deep_extend("force", {}, M.config, opts or {})
+    M.config = vim.tbl_deep_extend("force", {}, M.config, opts or {})
 
-  local picker_name = type(M.config.picker) == "table" and M.config.picker[1] or M.config.picker
-  local default_picker_opts = M.picker_config[picker_name] or {}
+    local picker_name = type(M.config.picker) == "table" and M.config.picker[1] or M.config.picker
+    local default_picker_opts = M.picker_config[picker_name] or {}
 
-  if type(M.config.picker) == "string" then
-    M.config.picker = {
-      M.config.picker,
-      opts = vim.tbl_deep_extend("force", {}, default_picker_opts),
-    }
-  else
-    if not M.config.picker.opts then
-      M.config.picker.opts = vim.tbl_deep_extend("force", {}, default_picker_opts)
-    else
-      M.config.picker.opts =
-        vim.tbl_deep_extend("force", {}, default_picker_opts, M.config.picker.opts)
+    if type(default_picker_opts) == "function" then
+        default_picker_opts = default_picker_opts(picker_name)
+        print(default_picker_opts)
     end
-  end
 
-  picker_util.init_picker(M.config.picker)
-  highlights.setup_highlights(M.config.signs)
+    if type(M.config.picker) == "string" then
+        M.config.picker = {
+            M.config.picker,
+            opts = vim.tbl_deep_extend("force", {}, default_picker_opts),
+        }
+    else
+        if not M.config.picker.opts then
+            M.config.picker.opts = vim.tbl_deep_extend("force", {}, default_picker_opts)
+        else
+            M.config.picker.opts =
+                vim.tbl_deep_extend("force", {}, default_picker_opts, M.config.picker.opts)
+        end
+    end
 
-  M.backend = init_backend(M.config.backend)
-  M.match_hl_kind = highlights.match_hl_kind or {}
+    picker_util.init_picker(M.config.picker)
+    highlights.setup_highlights(M.config.signs)
+
+    M.backend = init_backend(M.config.backend)
+    M.match_hl_kind = highlights.match_hl_kind or {}
 end
 
 return M

--- a/lua/tiny-code-action/pickers/telescope.lua
+++ b/lua/tiny-code-action/pickers/telescope.lua
@@ -5,144 +5,144 @@ local M = BasePicker.new()
 -- Initialize telescope modules
 local actions, action_state, pickers, finders, conf
 local function init_telescope()
-    if not M.has_dependency("Telescope.nvim", "telescope") then
-        return false
-    end
+  if not M.has_dependency("Telescope.nvim", "telescope") then
+    return false
+  end
 
-    actions = require("telescope.actions")
-    action_state = require("telescope.actions.state")
-    pickers = require("telescope.pickers")
-    finders = require("telescope.finders")
-    conf = require("telescope.config").values
-    return true
+  actions = require("telescope.actions")
+  action_state = require("telescope.actions.state")
+  pickers = require("telescope.pickers")
+  finders = require("telescope.finders")
+  conf = require("telescope.config").values
+  return true
 end
 
 local function create_displayer(width_message)
-    local display = require("telescope.pickers.entry_display").create({
-        separator = " ",
-        items = {
-            { width = 2 },
-            { width = width_message },
-            { remaining = true },
-        },
+  local display = require("telescope.pickers.entry_display").create({
+    separator = " ",
+    items = {
+      { width = 2 },
+      { width = width_message },
+      { remaining = true },
+    },
+  })
+  return function(entry_props)
+    return display({
+      { entry_props.kind,                 entry_props.kind_hl },
+      { entry_props.ordinal },
+      { "(" .. entry_props.client .. ")", "TelescopeResultsComment" },
     })
-    return function(entry_props)
-        return display({
-            { entry_props.kind,                 entry_props.kind_hl },
-            { entry_props.ordinal },
-            { "(" .. entry_props.client .. ")", "TelescopeResultsComment" },
-        })
-    end
+  end
 end
 
 local function prepare_entry_display(values)
-    local max_width_message = 0
+  local max_width_message = 0
 
-    for _, entry in pairs(values) do
-        local action = entry.action
-        local width = vim.fn.strdisplaywidth(action.title)
-        if width > max_width_message then
-            max_width_message = width
-        end
+  for _, entry in pairs(values) do
+    local action = entry.action
+    local width = vim.fn.strdisplaywidth(action.title)
+    if width > max_width_message then
+      max_width_message = width
     end
+  end
 
-    return create_displayer(max_width_message)
+  return create_displayer(max_width_message)
 end
 
 function M.create(config, results, bufnr)
-    if not init_telescope() then
-        return
-    end
+  if not init_telescope() then
+    return
+  end
 
-    M.config = config
-    local previewer_module = M.init_previewer("telescope", config)
-    local make_display = prepare_entry_display(results)
+  M.config = config
+  local previewer_module = M.init_previewer("telescope", config)
+  local make_display = prepare_entry_display(results)
 
-    local picker_opts = {
-        prompt_title = "Code Actions",
-        finder = finders.new_table({
-            results = results,
-            entry_maker = function(pair_client_action)
-                local action = pair_client_action.action
-                local client = pair_client_action.client
-                local context = pair_client_action.context
+  local picker_opts = {
+    prompt_title = "Code Actions",
+    finder = finders.new_table({
+      results = results,
+      entry_maker = function(pair_client_action)
+        local action = pair_client_action.action
+        local client = pair_client_action.client
+        local context = pair_client_action.context
 
-                local formatted = M.format_code_action({
-                    action = action,
-                    client = client,
-                })
+        local formatted = M.format_code_action({
+          action = action,
+          client = client,
+        })
 
-                return {
-                    value = pair_client_action,
-                    kind = formatted.kind,
-                    kind_hl = formatted.kind_hl,
-                    ordinal = formatted.ordinal,
-                    client = formatted.client,
-                    display = make_display,
-                }
-            end,
-        }),
-        sorter = conf.generic_sorter({}),
-        attach_mappings = function(prompt_bufnr, map)
-            -- Common function to apply code action
-            local apply_code_action = function(close_picker)
-                local selection = action_state.get_selected_entry()
-                if not selection then
-                    require("telescope.utils").__warn_no_selection("code_action")
-                    return
-                end
+        return {
+          value = pair_client_action,
+          kind = formatted.kind,
+          kind_hl = formatted.kind_hl,
+          ordinal = formatted.ordinal,
+          client = formatted.client,
+          display = make_display,
+        }
+      end,
+    }),
+    sorter = conf.generic_sorter({}),
+    attach_mappings = function(prompt_bufnr, map)
+      -- Common function to apply code action
+      local apply_code_action = function(close_picker)
+        local selection = action_state.get_selected_entry()
+        if not selection then
+          require("telescope.utils").__warn_no_selection("code_action")
+          return
+        end
 
-                local action = selection.value.action
-                local client = selection.value.client
-                local context = selection.value.context
+        local action = selection.value.action
+        local client = selection.value.client
+        local context = selection.value.context
 
-                if close_picker then
-                    actions.close(prompt_bufnr)
-                end
+        if close_picker then
+          actions.close(prompt_bufnr)
+        end
 
-                M.apply_action(action, client, context, bufnr)
+        M.apply_action(action, client, context, bufnr)
 
-                if not close_picker then
-                    -- Remove the applied action from the results to provide visual feedback
-                    local current_picker = action_state.get_current_picker(prompt_bufnr)
-                    if current_picker then
-                        current_picker:delete_selection(function(selection)
-                            -- Remove this entry from the results
-                            return true
-                        end)
-                    end
-                    vim.notify("Applied: " .. action.title, vim.log.levels.INFO)
-                end
-            end
-
-            -- Replace default select to close picker
-            actions.select_default:replace(function()
-                apply_code_action(true)
+        if not close_picker then
+          -- Remove the applied action from the results to provide visual feedback
+          local current_picker = action_state.get_current_picker(prompt_bufnr)
+          if current_picker then
+            current_picker:delete_selection(function(selection)
+              -- Remove this entry from the results
+              return true
             end)
+          end
+          vim.notify("Applied: " .. action.title, vim.log.levels.INFO)
+        end
+      end
 
-            -- Add custom keybind to apply without closing
-            map({ "n", "i" }, "<C-CR>", function()
-                apply_code_action(false)
-            end)
+      -- Replace default select to close picker
+      actions.select_default:replace(function()
+        apply_code_action(true)
+      end)
 
-            return true
-        end,
-    }
+      -- Add custom keybind to apply without closing
+      map({ "n", "i" }, "<C-CR>", function()
+        apply_code_action(false)
+      end)
 
-    if type(config.picker.opts.layout_config) == "function" then
-        config.picker.opts.layout_config = config.picker.opts.layout_config(config.picker.opts.layout_strategy);
-    end
+      return true
+    end,
+  }
 
-    if type(config.picker) == "table" then
-        picker_opts = vim.tbl_deep_extend("force", config.picker.opts or {}, picker_opts)
-    end
+  if type(config.picker.opts.layout_config) == "function" then
+    config.picker.opts.layout_config = config.picker.opts.layout_config(config.picker.opts.layout_strategy);
+  end
 
-    if picker_opts.previewer == nil then
-        picker_opts.previewer = previewer_module.create_previewer(bufnr)
-    end
+  if type(config.picker) == "table" then
+    picker_opts = vim.tbl_deep_extend("force", config.picker.opts or {}, picker_opts)
+  end
 
-    local picker = pickers.new({}, picker_opts)
-    picker:find()
+  if picker_opts.previewer == nil then
+    picker_opts.previewer = previewer_module.create_previewer(bufnr)
+  end
+
+  local picker = pickers.new({}, picker_opts)
+  picker:find()
 end
 
 return M

--- a/lua/tiny-code-action/pickers/telescope.lua
+++ b/lua/tiny-code-action/pickers/telescope.lua
@@ -5,140 +5,144 @@ local M = BasePicker.new()
 -- Initialize telescope modules
 local actions, action_state, pickers, finders, conf
 local function init_telescope()
-  if not M.has_dependency("Telescope.nvim", "telescope") then
-    return false
-  end
+    if not M.has_dependency("Telescope.nvim", "telescope") then
+        return false
+    end
 
-  actions = require("telescope.actions")
-  action_state = require("telescope.actions.state")
-  pickers = require("telescope.pickers")
-  finders = require("telescope.finders")
-  conf = require("telescope.config").values
-  return true
+    actions = require("telescope.actions")
+    action_state = require("telescope.actions.state")
+    pickers = require("telescope.pickers")
+    finders = require("telescope.finders")
+    conf = require("telescope.config").values
+    return true
 end
 
 local function create_displayer(width_message)
-  local display = require("telescope.pickers.entry_display").create({
-    separator = " ",
-    items = {
-      { width = 2 },
-      { width = width_message },
-      { remaining = true },
-    },
-  })
-  return function(entry_props)
-    return display({
-      { entry_props.kind, entry_props.kind_hl },
-      { entry_props.ordinal },
-      { "(" .. entry_props.client .. ")", "TelescopeResultsComment" },
+    local display = require("telescope.pickers.entry_display").create({
+        separator = " ",
+        items = {
+            { width = 2 },
+            { width = width_message },
+            { remaining = true },
+        },
     })
-  end
+    return function(entry_props)
+        return display({
+            { entry_props.kind,                 entry_props.kind_hl },
+            { entry_props.ordinal },
+            { "(" .. entry_props.client .. ")", "TelescopeResultsComment" },
+        })
+    end
 end
 
 local function prepare_entry_display(values)
-  local max_width_message = 0
+    local max_width_message = 0
 
-  for _, entry in pairs(values) do
-    local action = entry.action
-    local width = vim.fn.strdisplaywidth(action.title)
-    if width > max_width_message then
-      max_width_message = width
+    for _, entry in pairs(values) do
+        local action = entry.action
+        local width = vim.fn.strdisplaywidth(action.title)
+        if width > max_width_message then
+            max_width_message = width
+        end
     end
-  end
 
-  return create_displayer(max_width_message)
+    return create_displayer(max_width_message)
 end
 
 function M.create(config, results, bufnr)
-  if not init_telescope() then
-    return
-  end
+    if not init_telescope() then
+        return
+    end
 
-  M.config = config
-  local previewer_module = M.init_previewer("telescope", config)
-  local make_display = prepare_entry_display(results)
+    M.config = config
+    local previewer_module = M.init_previewer("telescope", config)
+    local make_display = prepare_entry_display(results)
 
-  local picker_opts = {
-    prompt_title = "Code Actions",
-    finder = finders.new_table({
-      results = results,
-      entry_maker = function(pair_client_action)
-        local action = pair_client_action.action
-        local client = pair_client_action.client
-        local context = pair_client_action.context
+    local picker_opts = {
+        prompt_title = "Code Actions",
+        finder = finders.new_table({
+            results = results,
+            entry_maker = function(pair_client_action)
+                local action = pair_client_action.action
+                local client = pair_client_action.client
+                local context = pair_client_action.context
 
-        local formatted = M.format_code_action({
-          action = action,
-          client = client,
-        })
+                local formatted = M.format_code_action({
+                    action = action,
+                    client = client,
+                })
 
-        return {
-          value = pair_client_action,
-          kind = formatted.kind,
-          kind_hl = formatted.kind_hl,
-          ordinal = formatted.ordinal,
-          client = formatted.client,
-          display = make_display,
-        }
-      end,
-    }),
-    sorter = conf.generic_sorter({}),
-    attach_mappings = function(prompt_bufnr, map)
-      -- Common function to apply code action
-      local apply_code_action = function(close_picker)
-        local selection = action_state.get_selected_entry()
-        if not selection then
-          require("telescope.utils").__warn_no_selection("code_action")
-          return
-        end
+                return {
+                    value = pair_client_action,
+                    kind = formatted.kind,
+                    kind_hl = formatted.kind_hl,
+                    ordinal = formatted.ordinal,
+                    client = formatted.client,
+                    display = make_display,
+                }
+            end,
+        }),
+        sorter = conf.generic_sorter({}),
+        attach_mappings = function(prompt_bufnr, map)
+            -- Common function to apply code action
+            local apply_code_action = function(close_picker)
+                local selection = action_state.get_selected_entry()
+                if not selection then
+                    require("telescope.utils").__warn_no_selection("code_action")
+                    return
+                end
 
-        local action = selection.value.action
-        local client = selection.value.client
-        local context = selection.value.context
+                local action = selection.value.action
+                local client = selection.value.client
+                local context = selection.value.context
 
-        if close_picker then
-          actions.close(prompt_bufnr)
-        end
+                if close_picker then
+                    actions.close(prompt_bufnr)
+                end
 
-        M.apply_action(action, client, context, bufnr)
+                M.apply_action(action, client, context, bufnr)
 
-        if not close_picker then
-          -- Remove the applied action from the results to provide visual feedback
-          local current_picker = action_state.get_current_picker(prompt_bufnr)
-          if current_picker then
-            current_picker:delete_selection(function(selection)
-              -- Remove this entry from the results
-              return true
+                if not close_picker then
+                    -- Remove the applied action from the results to provide visual feedback
+                    local current_picker = action_state.get_current_picker(prompt_bufnr)
+                    if current_picker then
+                        current_picker:delete_selection(function(selection)
+                            -- Remove this entry from the results
+                            return true
+                        end)
+                    end
+                    vim.notify("Applied: " .. action.title, vim.log.levels.INFO)
+                end
+            end
+
+            -- Replace default select to close picker
+            actions.select_default:replace(function()
+                apply_code_action(true)
             end)
-          end
-          vim.notify("Applied: " .. action.title, vim.log.levels.INFO)
-        end
-      end
 
-      -- Replace default select to close picker
-      actions.select_default:replace(function()
-        apply_code_action(true)
-      end)
+            -- Add custom keybind to apply without closing
+            map({ "n", "i" }, "<C-CR>", function()
+                apply_code_action(false)
+            end)
 
-      -- Add custom keybind to apply without closing
-      map({ "n", "i" }, "<C-CR>", function()
-        apply_code_action(false)
-      end)
+            return true
+        end,
+    }
 
-      return true
-    end,
-  }
+    if type(config.picker.opts.layout_config) == "function" then
+        config.picker.opts.layout_config = config.picker.opts.layout_config(config.picker.opts.layout_strategy);
+    end
 
-  if type(config.picker) == "table" then
-    picker_opts = vim.tbl_deep_extend("force", config.picker.opts or {}, picker_opts)
-  end
+    if type(config.picker) == "table" then
+        picker_opts = vim.tbl_deep_extend("force", config.picker.opts or {}, picker_opts)
+    end
 
-  if picker_opts.previewer == nil then
-    picker_opts.previewer = previewer_module.create_previewer(bufnr)
-  end
+    if picker_opts.previewer == nil then
+        picker_opts.previewer = previewer_module.create_previewer(bufnr)
+    end
 
-  local picker = pickers.new({}, picker_opts)
-  picker:find()
+    local picker = pickers.new({}, picker_opts)
+    picker:find()
 end
 
 return M


### PR DESCRIPTION
So my telescope complains about the layout settings when using horizontal layout, this setting changes the telescope picker to allow a function that returns the layout settings(config.lua), the function receives the  layout name as a parameter, and returns the settings, in the init.lua file and the telescope.lua file, if the layout configuration is a function, it runs the function to get the settings for the layout.

If this is something that's useful, I'll fix up PRs formatting issue.