### PR TITLE
feat: add support for fzf-lua

### DIFF
--- a/lua/tiny-code-action/config.lua
+++ b/lua/tiny-code-action/config.lua
@@ -5,6 +5,7 @@ M.VALID_PICKERS = {
   snacks = true,
   select = true,
   buffer = true,
+  ["fzf-lua"] = true,
 }
 
 M.VALID_BACKENDS = {

--- a/lua/tiny-code-action/picker.lua
+++ b/lua/tiny-code-action/picker.lua
@@ -29,6 +29,9 @@ function M.get_picker_module(picker_name)
   elseif picker_name == "select" then
     vim.notify("Select picker is not available. Falling back to buffer.", vim.log.levels.WARN)
     return M.get_picker_module("buffer")
+  elseif picker_name == "fzf-lua" then
+    vim.notify("Fzflua picker is not available. No picker could be loaded.", vim.log.levels.ERROR)
+    return M.get_picker_module("select")
   elseif picker_name == "buffer" then
     vim.notify("Buffer picker is not available. No picker could be loaded.", vim.log.levels.ERROR)
     return nil

--- a/lua/tiny-code-action/pickers/fzf-lua.lua
+++ b/lua/tiny-code-action/pickers/fzf-lua.lua
@@ -1,0 +1,120 @@
+local BasePicker = require("tiny-code-action.base.picker")
+
+local M = BasePicker.new()
+
+local function format_code_action(item)
+  local formatted = M.format_code_action(item)
+
+  return {
+    { formatted.kind, formatted.kind_hl },
+    { "  " },
+    { formatted.ordinal, "FzfLuaNormal" },
+    { " (" .. formatted.client .. ")", "Comment" },
+  }
+end
+
+M.get_ctx_extracted = function(selected, items, actions)
+  local fzflua_util = require("fzf-lua.utils")
+
+  local str_ic = fzflua_util.strip_ansi_coloring(selected)
+
+  local idx = 0
+
+  for i, v in pairs(items) do
+    local v_str = fzflua_util.strip_ansi_coloring(v)
+    if v_str == str_ic then
+      idx = i
+    end
+  end
+
+  return actions[idx]
+end
+
+function M.create(config, results, bufnr)
+  if not M.has_dependency("fzf-lua", "fzf-lua") then
+    return
+  end
+
+  local fzflua = require("fzf-lua")
+
+  local items = {}
+  local actions = {}
+
+  M.config = config
+
+  for i, result in ipairs(results) do
+    local action = result.action
+    local client = result.client
+    local context = result.context
+
+    actions[i] = {
+      client = client,
+      action = action,
+      context = context,
+    }
+
+    local formatted_action
+    for _, act in pairs(actions) do
+      formatted_action = format_code_action(act)
+    end
+
+    local _kind = formatted_action[1]
+    local _desc = formatted_action[3]
+    local _from_client = formatted_action[4]
+
+    local kind_w_hl = fzflua.utils.ansi_from_hl(_kind[2], _kind[1])
+    local desc_w_hl = fzflua.utils.ansi_from_hl(_desc[2], _desc[1])
+    local client_w_hl = fzflua.utils.ansi_from_hl(_from_client[2], _from_client[1])
+
+    table.insert(items, string.format("%s %s %s", kind_w_hl, desc_w_hl, client_w_hl))
+  end
+
+  ---@diagnostic disable: missing-fields
+  ---@type fzf-lua.config.Winopts
+  local winopts = {
+    title = "Code actions",
+    height = 0.65,
+    width = 0.70,
+    col = 0.50,
+    row = 0.50,
+    preview = {
+      hidden = false,
+      layout = "vertical",
+      vertical = "up:60%",
+    },
+  }
+
+  if type(config.picker) == "table" then
+    winopts = vim.tbl_deep_extend("force", winopts, config.picker.opts.winopts or {})
+  end
+
+  local previewer = M.init_previewer("fzf-lua", config)
+
+  ---@diagnostic disable: missing-fields
+  ---@type fzf-lua.config.Defaults
+  local picker_opts = {
+    previewer = previewer.term_previewer({
+      bufnr = bufnr,
+      items = items,
+      actions = actions,
+    }),
+    actions = {
+      ["default"] = function(selected, _)
+        if not selected then
+          return
+        end
+
+        local sel = M.get_ctx_extracted(selected[1], items, actions)
+        if sel then
+          M.apply_action(sel.action, sel.client, sel.context, bufnr)
+        end
+      end,
+    },
+  }
+
+  picker_opts.winopts = winopts
+
+  return fzflua.fzf_exec(items, picker_opts)
+end
+
+return M

--- a/lua/tiny-code-action/previewers/fzf-lua.lua
+++ b/lua/tiny-code-action/previewers/fzf-lua.lua
@@ -1,0 +1,85 @@
+local BasePreviewer = require("tiny-code-action.base.previewer")
+local fzf_picker = require("tiny-code-action.pickers.fzf-lua")
+local utils = require("tiny-code-action.utils")
+
+local M = BasePreviewer.new()
+
+local function extract_preview_data(entry, opts)
+  local ctx = fzf_picker.get_ctx_extracted(entry, opts.items, opts.actions)
+  if not ctx then
+    return { "No preview available for this action" }
+  end
+
+  local action = ctx.action
+  local client = ctx.client
+
+  local preview_content = M.preview_with_resolve(action, opts.bufnr, client)
+  if not preview_content or vim.tbl_isempty(preview_content) then
+    preview_content = { "No preview available for this action" }
+  end
+
+  return preview_content
+end
+
+local function preview_cmd(opts)
+  local fzf_fzf = require("fzf-lua.previewer.fzf")
+  local shell = require("fzf-lua.shell")
+
+  local CodeActionPreviewerCmd = fzf_fzf.cmd_async:extend()
+
+  function CodeActionPreviewerCmd:new(o, optsc)
+    CodeActionPreviewerCmd.super.new(self, o, optsc)
+    setmetatable(self, CodeActionPreviewerCmd)
+    return self
+  end
+
+  function CodeActionPreviewerCmd:cmdline(o)
+    o = o or {}
+    return shell.stringify_cmd(function(entry_str)
+      if type(entry_str) ~= "table" then
+        return "echo 'No preview available for this action'"
+      end
+
+      local preview_content = extract_preview_data(entry_str[1], opts)
+      local text = table.concat(preview_content, "\n")
+      return "echo '" .. text .. "'"
+    end, {}, "{}")
+  end
+
+  return CodeActionPreviewerCmd
+end
+
+local function preview_buf(opts)
+  local fzf_builtin = require("fzf-lua.previewer.builtin")
+
+  local CodeActionPreviewerBuf = fzf_builtin.buffer_or_file:extend()
+
+  function CodeActionPreviewerBuf:new(o, optsc, fzf_win)
+    CodeActionPreviewerBuf.super.new(self, o, optsc, fzf_win)
+    setmetatable(self, CodeActionPreviewerBuf)
+    return self
+  end
+
+  function CodeActionPreviewerBuf:populate_preview_buf(entry_str)
+    local preview_content = extract_preview_data(entry_str, opts)
+
+    local temp_buf = self:get_tmp_buffer()
+    vim.api.nvim_buf_set_lines(temp_buf, 0, -1, false, preview_content)
+    utils.set_buf_option(temp_buf, "filetype", "diff")
+
+    self:set_preview_buf(temp_buf)
+    self.win:update_preview_scrollbar()
+  end
+
+  return CodeActionPreviewerBuf
+end
+
+function M.term_previewer(opts)
+  local backend_name = M.config and M.config.backend or "vim"
+  if not backend_name or backend_name == "vim" then
+    return preview_buf(opts)
+  end
+  return preview_cmd(opts)
+end
+
+return M

--- a/lua/tiny-code-action/previewers/fzf-lua.lua
+++ b/lua/tiny-code-action/previewers/fzf-lua.lua
@@ -63,8 +63,20 @@ local function preview_buf(opts)
   function CodeActionPreviewerBuf:populate_preview_buf(entry_str)
     local preview_content = extract_preview_data(entry_str, opts)
 
+    local sanitized_preview = {}
+
+    for _, line in ipairs(preview_content) do
+      if type(line) == "string" and line:find("\n") then
+        local split_lines = vim.split(line, "\n", { plain = true })
+        vim.list_extend(sanitized_preview, split_lines)
+      else
+        table.insert(sanitized_preview, line)
+      end
+    end
+
     local temp_buf = self:get_tmp_buffer()
-    vim.api.nvim_buf_set_lines(temp_buf, 0, -1, false, preview_content)
+
+    vim.api.nvim_buf_set_lines(temp_buf, 0, -1, false, sanitized_preview)
     utils.set_buf_option(temp_buf, "filetype", "diff")
 
     self:set_preview_buf(temp_buf)


### PR DESCRIPTION
This PR adds support for `fzf-lua`. The default `select` doesn't include a preview window, so I've added one for better usability.

I haven't updated the README, as the configuration remains mostly the same.

For `fzf-lua` users, only the `winopts` section needs to be set for layout, which they are typically familiar with.

I’ll leave any README changes up to the author’s discretion.