### PR TITLE
fix(terminal): fix terminal colorize from replacing all [ chars

### DIFF
--- a/lua/tiny-code-action/terminal/init.lua
+++ b/lua/tiny-code-action/terminal/init.lua
@@ -40,7 +40,7 @@ function M.colorize(buf, opts)
         end
       end)
 
-      cleaned = cleaned:gsub("%[", "\027[")
+      cleaned = cleaned:gsub("\\27%[", "\27[")
       table.insert(cleaned_lines, cleaned)
     end
 


### PR DESCRIPTION
The gsub was incorrectly replacing every `[` char, which led to malformed rendering.

Before:
<img width="406" height="144" alt="image" src="https://github.com/user-attachments/assets/60f04528-b3f3-47f5-8649-685dad961294" />
<img width="378" height="80" alt="image" src="https://github.com/user-attachments/assets/a410bbf2-eabd-4707-8845-41ede46577fb" />

After:
<img width="384" height="145" alt="image" src="https://github.com/user-attachments/assets/91b7b13f-a300-47fb-94fc-3f2654eb7929" />
<img width="389" height="150" alt="image" src="https://github.com/user-attachments/assets/b6838ef3-ccd2-40a5-aa73-d90cb9586955" />
