### PR TITLE
fix(backend): ensure dir temp exists

### DIFF
--- a/lua/tiny-code-action/base/backend.lua
+++ b/lua/tiny-code-action/base/backend.lua
@@ -21,6 +21,17 @@ function BaseBackendFiles:prepare_files(bufnr, old_lines, new_lines)
   old_lines = vim.split(table.concat(old_lines, "\n"), "\n")
   new_lines = vim.split(table.concat(new_lines, "\n"), "\n")
 
+  ---@param path string
+  local function ensure_dir_exists(path)
+    local dir = vim.fn.fnamemodify(path, ":h")
+    if vim.fn.isdirectory(dir) == 0 then
+      vim.fn.mkdir(dir, "p")
+    end
+  end
+
+  ensure_dir_exists(old_file)
+  ensure_dir_exists(new_file)
+
   vim.fn.writefile(old_lines, old_file)
   vim.fn.writefile(new_lines, new_file)
 


### PR DESCRIPTION
This PR fixes an issue where the plugin fails to write preview files because the temporary directory doesn’t exist.
