### PR TITLE
fix: consider borders when centering window

### DIFF
--- a/lua/tiny-code-action/pickers/buffer_utils/window.lua
+++ b/lua/tiny-code-action/pickers/buffer_utils/window.lua
@@ -22,14 +22,25 @@ local function calculate_window_position(lines, config)
   if parent_win_coords then
     return width, height, parent_win_coords.row, parent_win_coords.col
   end
+
   local row, col, win_row, win_col, shift
   local position = config.picker and config.picker.opts and config.picker.opts.position or "cursor"
 
   if position == "center" then
     local nvim_width = vim.o.columns
     local nvim_height = vim.o.lines
-    row = math.floor((nvim_height - height) / 2)
-    col = math.floor((nvim_width - width) / 2)
+
+    local inner_width = width
+    local inner_height = height
+
+    local border_width = 1
+    local borders = border_width * 2
+
+    local full_width = inner_width + borders
+    local full_height = inner_height + borders
+
+    row = math.floor((nvim_height - full_height) / 2)
+    col = math.floor((nvim_width - full_width) / 2)
   else
     win_row, win_col = unpack(vim.api.nvim_win_get_position(0))
     row = vim.fn.winline()
@@ -284,7 +295,13 @@ function M.create_main_window(
     end
 
     if action_item and apply_action_fn then
-      apply_action_fn(action_item.action, action_item.client, action_item.context, bufnr, action_item._resolved_action)
+      apply_action_fn(
+        action_item.action,
+        action_item.client,
+        action_item.context,
+        bufnr,
+        action_item._resolved_action
+      )
     end
     vim.api.nvim_win_close(win, true)
     preview.close_preview()


### PR DESCRIPTION
After considering borders, the window is going to be rendered a bit upper than it was before, more eye comfortable.