### PR TITLE
fix(snacks): use correct title property for the picker

### DIFF
--- a/lua/tiny-code-action/pickers/snacks.lua
+++ b/lua/tiny-code-action/pickers/snacks.lua
@@ -49,7 +49,7 @@ function M.create(config, results, bufnr)
   end
 
   local picker_opts = {
-    prompt_title = "Code Actions",
+    title = "Code Actions",
     items = items,
     format = function(item)
       return format_code_action(item)


### PR DESCRIPTION
Currently the prompt title window falls back to the snacks default instead of using the expected title as declared. Fix this by using the correct snacks picker property to set the window title.