### PR TITLE
fix(snacks): hide [Process exited \d] virtual text in terminal previewer

### DIFF
--- a/lua/tiny-code-action/previewers/snacks.lua
+++ b/lua/tiny-code-action/previewers/snacks.lua
@@ -43,6 +43,19 @@ function M.term_previewer(opts)
       -- Use terminal preview for other content types
       local text = table.concat(preview_content, "\n")
       snacks_preview.cmd(utils.create_echo_command(text), ctx)
+
+      -- hide [Process exited 0] in terminal preview
+      local grp = vim.api.nvim_create_augroup("tiny-code-action", {})
+      vim.api.nvim_create_autocmd("TermClose", {
+        group = grp,
+        callback = function(event)
+          if event.buf == ctx.buf then
+            local exitmsg_ns = vim.api.nvim_get_namespaces()["nvim.terminal.exitmsg"]
+            vim.api.nvim_buf_clear_namespace(event.buf, exitmsg_ns, 0, -1)
+            vim.api.nvim_del_augroup_by_id(grp)
+          end
+        end,
+      })
     end
 
     return true


### PR DESCRIPTION
The solution from https://github.com/rachartier/tiny-code-action.nvim/pull/52#issuecomment-3067054444 to hide `[Process exited 0]` messages no longer works: since https://github.com/neovim/neovim/pull/37987#discussion_r2867491017, the exit code of the process running in a terminal is displayed as virtual text. To get rid of it, I haven't found a better solution than clearing its namespace in an autocmd.